### PR TITLE
fix: The certificate path in the ca-certificates.conf file on the dee…

### DIFF
--- a/core/system_linux.go
+++ b/core/system_linux.go
@@ -112,8 +112,6 @@ func (s *SystemSetup) installCert() (string, error) {
 		confPath := "/etc/ca-certificates.conf"
 		checkCmd := []string{"grep", "-qxF", certName, confPath}
 		if _, err := s.runCommand(checkCmd, true); err != nil {
-			// certPath = "/usr/share/ca-certificates/" + appOnce.AppName + "/" + certName
-			// Therefore, in the conf file, it should be set to `appOnce.AppName + "/" + certName` instead of `certName`.
 			echoCmd := []string{"bash", "-c", fmt.Sprintf("echo '%s' >> %s", appOnce.AppName+"/"+certName, confPath)}
 			if output, err := s.runCommand(echoCmd, true); err != nil {
 				errs.WriteString(fmt.Sprintf("append conf failed: %s\n%s\n", err.Error(), output))

--- a/core/system_linux.go
+++ b/core/system_linux.go
@@ -112,7 +112,9 @@ func (s *SystemSetup) installCert() (string, error) {
 		confPath := "/etc/ca-certificates.conf"
 		checkCmd := []string{"grep", "-qxF", certName, confPath}
 		if _, err := s.runCommand(checkCmd, true); err != nil {
-			echoCmd := []string{"bash", "-c", fmt.Sprintf("echo '%s' >> %s", certName, confPath)}
+			// certPath = "/usr/share/ca-certificates/" + appOnce.AppName + "/" + certName
+			// Therefore, in the conf file, it should be set to `appOnce.AppName + "/" + certName` instead of `certName`.
+			echoCmd := []string{"bash", "-c", fmt.Sprintf("echo '%s' >> %s", appOnce.AppName+"/"+certName, confPath)}
 			if output, err := s.runCommand(echoCmd, true); err != nil {
 				errs.WriteString(fmt.Sprintf("append conf failed: %s\n%s\n", err.Error(), output))
 			} else {


### PR DESCRIPTION
deepin发行版上面，ca-certificates.conf 文件中设置的证书路径与实际路径不匹配，导致update-ca-certificates会执行失败。

res-downloader.crt存放在`"/usr/share/ca-certificates/" + appOnce.AppName + "/" + certName`，以`/usr/share/ca-certificates/`来取相对路径的话就是`appOnce.AppName + "/" + certName`。因此ca-certificates.conf中写入的证书路径应该是`appOnce.AppName + "/" + certName`，而不是`certName`