### PR TITLE
fix(security): generate per-machine CA and cleanup trusted certs

### DIFF
--- a/build/windows/installer/project.nsi
+++ b/build/windows/installer/project.nsi
@@ -100,6 +100,9 @@ SectionEnd
 Section "uninstall"
     !insertmacro wails.setShellContext
 
+    IfFileExists "$INSTDIR\${PRODUCT_EXECUTABLE}" 0 +2
+    ExecWait '"$INSTDIR\${PRODUCT_EXECUTABLE}" --cleanup-system'
+
     RMDir /r "$AppData\${PRODUCT_EXECUTABLE}" # Remove the WebView2 DataPath
 
     RMDir /r $INSTDIR

--- a/core/app.go
+++ b/core/app.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"res-downloader/core/shared"
 	"strconv"
 	"time"
 )
@@ -22,7 +21,6 @@ type App struct {
 	Description string `json:"Description"`
 	Copyright   string `json:"Copyright"`
 	UserDir     string `json:"-"`
-	LockFile    string `json:"-"`
 	PublicCrt   []byte `json:"-"`
 	PrivateKey  []byte `json:"-"`
 	IsProxy     bool   `json:"IsProxy"`
@@ -40,90 +38,81 @@ var (
 	ruleOnce       *RuleSet
 )
 
-func GetApp(assets embed.FS, wjs string) *App {
-	if appOnce == nil {
-		matches := regexp.MustCompile(`"productVersion":\s*"([\d.]+)"`).FindStringSubmatch(wjs)
-		version := "1.0.1"
-		if len(matches) > 0 {
-			version = matches[1]
-		}
-
-		appOnce = &App{
-			assets:      assets,
-			AppName:     "res-downloader",
-			Version:     version,
-			Description: "res-downloader是一款集网络资源嗅探 + 高速下载功能于一体的软件，高颜值、高性能和多样化，提供个人用户下载自己上传到各大平台的网络资源功能！",
-			Copyright:   "Copyright © 2023~" + strconv.Itoa(time.Now().Year()),
-			IsReset:     false,
-			PublicCrt: []byte(`-----BEGIN CERTIFICATE-----
-MIIDwzCCAqugAwIBAgIUFAnC6268dp/z1DR9E1UepiWgWzkwDQYJKoZIhvcNAQEL
-BQAwcDELMAkGA1UEBhMCQ04xEjAQBgNVBAgMCUNob25ncWluZzESMBAGA1UEBwwJ
-Q2hvbmdxaW5nMQ4wDAYDVQQKDAVnb3dhczEWMBQGA1UECwwNSVQgRGVwYXJ0bWVu
-dDERMA8GA1UEAwwIZ293YXMuY24wIBcNMjQwMjE4MDIwOTI2WhgPMjEyNDAxMjUw
-MjA5MjZaMHAxCzAJBgNVBAYTAkNOMRIwEAYDVQQIDAlDaG9uZ3FpbmcxEjAQBgNV
-BAcMCUNob25ncWluZzEOMAwGA1UECgwFZ293YXMxFjAUBgNVBAsMDUlUIERlcGFy
-dG1lbnQxETAPBgNVBAMMCGdvd2FzLmNuMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEA3A7dt7eoqAaBxv2Npjo8Z7VkGvXT93jZfpgAuuNuQ5RLcnOnMzQC
-CrrjPcLfsAMA0AIK3eUWsXXKSR9SZTJBLQRZCJHZ9AIPfA+58JVQPTjd8UIuQZJf
-rDf6FjhPJTsLzcjTU+mT7t6lEimPEl2VWN9eXWqs9nkVrJtqLao6m1hoYfXOxRh6
-96/WgBtPHcmjujryteBiSITVflDjx+YQzDGsbqw7fM52klMPd2+w/vmhJ4pxq6P7
-Ni2OBvdXYDPIuLfPFFqG16arORjBkyNCJy19iOuh5LXh+EUX11wvbLwNgsTd8j9v
-eBSD+4HUUNQhiXiXJbs7I7cdFYthvb609QIDAQABo1MwUTAdBgNVHQ4EFgQUdI8p
-aY1A47rWCRvQKSTRCCk6FoMwHwYDVR0jBBgwFoAUdI8paY1A47rWCRvQKSTRCCk6
-FoMwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEArMCAfqidgXL7
-cW5TAZTCqnUeKzbbqMJgk6iFsma8scMRsUXz9ZhF0UVf98376KvoJpy4vd81afbi
-TehQ8wVBuKTtkHeh/MkXMWC/FU4HqSjtvxpic2+Or5dMjIrfa5VYPgzfqNaBIUh4
-InD5lo8b/n5V+jdwX7RX9VYAKug6QZlCg5YSKIvgNRChb36JmrGcvsp5R0Vejnii
-e3oowvgwikqm6XR6BEcRpPkztqcKST7jPFGHiXWsAqiibc+/plMW9qebhfMXEGhQ
-5yVNeSxX2zqasZvP/fRy+3I5iVilxtKvJuVpPZ0UZzGS0CJ/lF67ntibktiPa3sR
-D8HixYbEDg==
------END CERTIFICATE-----
-`),
-			PrivateKey: []byte(`-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDcDt23t6ioBoHG
-/Y2mOjxntWQa9dP3eNl+mAC6425DlEtyc6czNAIKuuM9wt+wAwDQAgrd5RaxdcpJ
-H1JlMkEtBFkIkdn0Ag98D7nwlVA9ON3xQi5Bkl+sN/oWOE8lOwvNyNNT6ZPu3qUS
-KY8SXZVY315daqz2eRWsm2otqjqbWGhh9c7FGHr3r9aAG08dyaO6OvK14GJIhNV+
-UOPH5hDMMaxurDt8znaSUw93b7D++aEninGro/s2LY4G91dgM8i4t88UWobXpqs5
-GMGTI0InLX2I66HkteH4RRfXXC9svA2CxN3yP294FIP7gdRQ1CGJeJcluzsjtx0V
-i2G9vrT1AgMBAAECggEAF0obfQ4a82183qqHC0iui+tOpOvPeyl3G0bLDPx09wIC
-2iITV//xF2GgGzE8q0wmEd2leMZ+GFn3BrYh6kPfUfxbz+RfxMtTCDZB34xt6YzT
-MG1op9ft+DQUa7WZ6r7NCQJwGzllRqqZncp4MeFlpPo+6nQXyh4WhSYNnredbENE
-uPZ63Kme4RZfMvtVso+XgAQM3oDih0onv1YitmNQpL9rRzlthTfybAT4737DBINq
-zsmBNE6QIsXnSKpzo11OtDgof2QM9ac6eAXf73oTpDxfodwCotILytKn+8WYvlR+
-T15uuknb4M3XI1FPVolkF4qtK5SLAAbVzV4DsCmuIQKBgQD6bTKKbL2huvU6dEKx
-bgS079LfQUxxOTClgwkhVsMxRtvcPBnHYMAsPK4mnMhEh9x+TF6wxMx0pmhQluPI
-ZULNBj/qdoiBL0RwVLA+9jgE0NeWB3XXFDsEavQBr9Q8CC0uzrsgsxFcvHpqqs2Q
-RtngxRWtJP06D6mKC23s4YjDHwKBgQDg9KUCFqOmWcRXyeg9gYMC4jFFQw4lUQBd
-sYpqSMHDw1b+T1W/dCPbwbxZL/+d8y930BYy9QYDtQwHdLyXCH0pHM7S6rfgr5xk
-2Szd8xBUIqmeV/zcR00mTeQHJ1M50VHfclAVgZgkpWSoLwbX+bXyx/mfqLAtynZ5
-yU9RfrT5awKBgQC0uJ8TlFvZXjFgyMvkfY/5/2R/ZwFCaFI573FkVNeyNP+vVNQJ
-tUGZ6wSGqvg/tIgjwPtIuA0QVZLMLcgeMy1dBhiUHIxwJetO4V77YPaWSxx5kdKx
-r1DT5FdI7FnOJNxufhQ/CdsKwJ3bYn3Mk8TiV3hIJnx0LR9dltfybeQjYwKBgDOY
-6aApATBOtrJMJXC2HA61QwfX8Y6tnZ/f8RefyJHWZEXAfLKFORRWw5TRZZgdB247
-1Furx81h4Xh0Vi1uTQb5DJdkLvjiTsTy60+dSMmDidQ/6ke8Mv3uL7dUVcqVMGpI
-FgZYy0TcitHot3EiXZFqPN9aGc7m+XXFruPKZEgxAoGBAMA96jsow7CzulU+GRW8
-Njg4zWuAEVErgPoNBcOXAVWLCTU/qGIEMNpZL6Ok34kf13pJDMjQ8eDuQHu5CSqf
-0ul5Zy85fwfVq2IvNAyYT8eflQprTejFw22CHhfPBfADVW9ro8dK/Jw+J/31Vh7V
-ILKEQKmPPzKs7kp/7Nz+2cT3
------END PRIVATE KEY-----
-`),
-		}
-		appOnce.UserDir = filepath.Join(userdir.GetConfigHome(), appOnce.AppName)
-		err := os.MkdirAll(appOnce.UserDir, 0750)
-		if err != nil {
-			fmt.Println("Mkdir UserDir err: ", err.Error())
-		}
-		appOnce.LockFile = filepath.Join(appOnce.UserDir, "install.lock")
-		initLogger()
-		initConfig()
-		initProxy()
-		initResource()
-		initHttpServer()
-		initSystem()
-		initRule()
+func initAppBase(wjs string) *App {
+	if appOnce != nil {
+		return appOnce
 	}
+
+	matches := regexp.MustCompile(`"productVersion":\s*"([\d.]+)"`).FindStringSubmatch(wjs)
+	version := "1.0.1"
+	if len(matches) > 0 {
+		version = matches[1]
+	}
+
+	appOnce = &App{
+		AppName:     "res-downloader",
+		Version:     version,
+		Description: "res-downloader是一款集网络资源嗅探 + 高速下载功能于一体的软件，高颜值、高性能和多样化，提供个人用户下载自己上传到各大平台的网络资源功能！",
+		Copyright:   "Copyright © 2023~" + strconv.Itoa(time.Now().Year()),
+		IsReset:     false,
+	}
+	appOnce.UserDir = filepath.Join(userdir.GetConfigHome(), appOnce.AppName)
+	if err := os.MkdirAll(appOnce.UserDir, 0750); err != nil {
+		fmt.Println("Mkdir UserDir err: ", err.Error())
+	}
+
 	return appOnce
+}
+
+func GetApp(assets embed.FS, wjs string) *App {
+	app := initAppBase(wjs)
+	app.assets = assets
+
+	initLogger()
+	initSystem()
+	if err := app.syncLocalCertificate(true); err != nil {
+		globalLogger.Esg(err, "init local certificate failed")
+		panic(err)
+	}
+
+	initConfig()
+	initProxy()
+	initResource()
+	initHttpServer()
+	initRule()
+
+	return app
+}
+
+func GetCliApp(wjs string) *App {
+	app := initAppBase(wjs)
+	initLogger()
+	initSystem()
+	if err := app.syncLocalCertificate(false); err != nil && !os.IsNotExist(err) {
+		globalLogger.Esg(err, "load local certificate for cli failed")
+	}
+	return app
+}
+
+func (a *App) syncLocalCertificate(createIfMissing bool) error {
+	var (
+		cert []byte
+		key  []byte
+		err  error
+	)
+
+	if createIfMissing {
+		cert, key, err = systemOnce.EnsureLocalCA()
+	} else {
+		cert, key, err = systemOnce.LoadLocalCA()
+	}
+	if err != nil {
+		return err
+	}
+
+	a.PublicCrt = cert
+	a.PrivateKey = key
+	return nil
 }
 
 func (a *App) Startup(ctx context.Context) {
@@ -132,7 +121,12 @@ func (a *App) Startup(ctx context.Context) {
 }
 
 func (a *App) OnExit() {
-	a.UnsetSystemProxy()
+	if err := a.UnsetSystemProxy(); err != nil {
+		globalLogger.Esg(err, "unset system proxy on exit failed")
+	}
+	if err := a.RemoveTrustedCert(); err != nil {
+		globalLogger.Esg(err, "remove trusted cert on exit failed")
+	}
 	globalLogger.Close()
 	if appOnce.IsReset {
 		err := a.ResetApp()
@@ -144,13 +138,16 @@ func (a *App) installCert() (string, error) {
 	out, err := systemOnce.installCert()
 	if err != nil {
 		globalLogger.Esg(err, out)
-		return out, err
-	} else {
-		if err := a.lock(); err != nil {
-			globalLogger.Err(err)
-		}
 	}
-	return out, nil
+	return out, err
+}
+
+func (a *App) RemoveTrustedCert() error {
+	err := systemOnce.removeCert()
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func (a *App) OpenSystemProxy() error {
@@ -178,15 +175,15 @@ func (a *App) UnsetSystemProxy() error {
 }
 
 func (a *App) isInstall() bool {
-	return shared.FileExist(a.LockFile)
-}
-
-func (a *App) lock() error {
-	err := os.WriteFile(a.LockFile, []byte("success"), 0644)
+	installed, err := systemOnce.isCertInstalled()
 	if err != nil {
-		return err
+		if os.IsNotExist(err) {
+			return false
+		}
+		globalLogger.Esg(err, "check trusted cert failed")
+		return false
 	}
-	return nil
+	return installed
 }
 
 func (a *App) ResetApp() error {
@@ -200,12 +197,37 @@ func (a *App) ResetApp() error {
 		return err
 	}
 
-	_ = os.Remove(filepath.Join(appOnce.UserDir, "install.lock"))
-	_ = os.Remove(filepath.Join(appOnce.UserDir, "pass.cache"))
+	if err := systemOnce.unsetProxy(); err != nil {
+		globalLogger.Esg(err, "unset proxy during reset failed")
+	}
+	if err := a.RemoveTrustedCert(); err != nil {
+		globalLogger.Esg(err, "remove cert during reset failed")
+	}
+
+	_ = os.Remove(systemOnce.CacheFile)
 	_ = os.Remove(filepath.Join(appOnce.UserDir, "config.json"))
-	_ = os.Remove(filepath.Join(appOnce.UserDir, "cert.crt"))
+	_ = os.Remove(systemOnce.CertFile)
+	_ = os.Remove(systemOnce.KeyFile)
 
 	cmd := exec.Command(exePath)
 	cmd.Start()
 	return nil
+}
+
+func CleanupSystemState(wjs string) error {
+	app := GetCliApp(wjs)
+	defer globalLogger.Close()
+
+	var firstErr error
+	if err := systemOnce.unsetProxy(); err != nil {
+		globalLogger.Esg(err, "cleanup unset proxy failed")
+		firstErr = err
+	}
+	if err := app.RemoveTrustedCert(); err != nil {
+		globalLogger.Esg(err, "cleanup remove cert failed")
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/core/logger.go
+++ b/core/logger.go
@@ -22,7 +22,9 @@ func initLogger() *Logger {
 }
 
 func (l *Logger) Close() {
-	_ = l.logFile.Close()
+	if l.logFile != nil {
+		_ = l.logFile.Close()
+	}
 }
 
 func (l *Logger) Err(err error) {

--- a/core/system.go
+++ b/core/system.go
@@ -1,14 +1,25 @@
 package core
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 type SystemSetup struct {
 	CertFile  string
+	KeyFile   string
 	CacheFile string
 	Password  string
 	aesCipher *AESCipher
@@ -18,7 +29,8 @@ func initSystem() *SystemSetup {
 	if systemOnce == nil {
 		systemOnce = &SystemSetup{
 			aesCipher: NewAESCipher("resd48w2d7er95627d447c490a8f02ff"),
-			CertFile:  filepath.Join(appOnce.UserDir, "cert.crt"),
+			CertFile:  filepath.Join(appOnce.UserDir, "ca.crt"),
+			KeyFile:   filepath.Join(appOnce.UserDir, "ca.key"),
 			CacheFile: filepath.Join(appOnce.UserDir, "pass.cache"),
 		}
 		systemOnce.checkPasswordFile()
@@ -26,20 +38,117 @@ func initSystem() *SystemSetup {
 	return systemOnce
 }
 
-func (s *SystemSetup) initCert() ([]byte, error) {
-	content, err := os.ReadFile(s.CertFile)
-	if err == nil {
-		return content, nil
+func GetSystemCertFile() string {
+	if systemOnce == nil {
+		return ""
 	}
-	if os.IsNotExist(err) {
-		err = os.WriteFile(s.CertFile, appOnce.PublicCrt, 0750)
-		if err != nil {
-			return nil, err
-		}
-		return appOnce.PublicCrt, nil
-	} else {
+	return systemOnce.CertFile
+}
+
+func (s *SystemSetup) EnsureLocalCA() ([]byte, []byte, error) {
+	cert, key, err := s.LoadLocalCA()
+	if err == nil {
+		return cert, key, nil
+	}
+	if !os.IsNotExist(err) {
+		fmt.Println("Reload local CA failed, regenerating:", err.Error())
+	}
+	return s.generateLocalCA()
+}
+
+func (s *SystemSetup) LoadLocalCA() ([]byte, []byte, error) {
+	certPEM, err := os.ReadFile(s.CertFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM, err := os.ReadFile(s.KeyFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := s.loadCertificate()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !cert.IsCA {
+		return nil, nil, fmt.Errorf("local certificate is not a CA")
+	}
+
+	return certPEM, keyPEM, nil
+}
+
+func (s *SystemSetup) loadCertificate() (*x509.Certificate, error) {
+	certPEM, err := os.ReadFile(s.CertFile)
+	if err != nil {
 		return nil, err
 	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode certificate pem")
+	}
+
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func (s *SystemSetup) generateLocalCA() ([]byte, []byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"res-downloader"},
+			CommonName:   "res-downloader Local CA",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+
+	if err := os.WriteFile(s.CertFile, certPEM, 0644); err != nil {
+		return nil, nil, err
+	}
+	if err := os.WriteFile(s.KeyFile, keyPEM, 0600); err != nil {
+		return nil, nil, err
+	}
+
+	return certPEM, keyPEM, nil
+}
+
+func (s *SystemSetup) certFingerprintSHA1() (string, error) {
+	cert, err := s.loadCertificate()
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha1.Sum(cert.Raw)
+	return strings.ToUpper(hex.EncodeToString(sum[:])), nil
 }
 
 func (s *SystemSetup) SetPassword(password string, isCache bool) {

--- a/core/system_darwin.go
+++ b/core/system_darwin.go
@@ -5,19 +5,22 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
-func (s *SystemSetup) runCommand(args []string) ([]byte, error) {
+func (s *SystemSetup) runCommand(args []string, sudo bool) ([]byte, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("no command provided")
 	}
 
 	var cmd *exec.Cmd
-	if s.Password != "" {
+	if sudo && s.Password != "" {
 		cmd = exec.Command("sudo", append([]string{"-S"}, args...)...)
 		cmd.Stdin = bytes.NewReader([]byte(s.Password + "\n"))
+	} else if sudo {
+		cmd = exec.Command("sudo", args...)
 	} else {
 		cmd = exec.Command(args[0], args[1:]...)
 	}
@@ -27,7 +30,7 @@ func (s *SystemSetup) runCommand(args []string) ([]byte, error) {
 }
 
 func (s *SystemSetup) getNetworkServices() ([]string, error) {
-	output, err := s.runCommand([]string{"networksetup", "-listallnetworkservices"})
+	output, err := s.runCommand([]string{"networksetup", "-listallnetworkservices"}, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute command: %v", err)
 	}
@@ -40,7 +43,7 @@ func (s *SystemSetup) getNetworkServices() ([]string, error) {
 			continue
 		}
 
-		infoOutput, err := s.runCommand([]string{"networksetup", "-getinfo", service})
+		infoOutput, err := s.runCommand([]string{"networksetup", "-getinfo", service}, false)
 		if err != nil {
 			fmt.Printf("failed to get info for service %s: %v\n", service, err)
 			continue
@@ -72,7 +75,7 @@ func (s *SystemSetup) setProxy() error {
 			{"networksetup", "-setsecurewebproxy", serviceName, "127.0.0.1", globalConfig.Port},
 		}
 		for _, cmd := range commands {
-			if output, err := s.runCommand(cmd); err != nil {
+			if output, err := s.runCommand(cmd, true); err != nil {
 				errs.WriteString(fmt.Sprintf("cmd: %v\noutput: %s\nerr: %s\n", cmd, output, err))
 			} else {
 				isSuccess = true
@@ -84,7 +87,7 @@ func (s *SystemSetup) setProxy() error {
 		return nil
 	}
 
-	return fmt.Errorf("failed to set proxy for any active network service, errs:%s", errs)
+	return fmt.Errorf("failed to set proxy for any active network service, errs:%s", errs.String())
 }
 
 func (s *SystemSetup) unsetProxy() error {
@@ -101,7 +104,7 @@ func (s *SystemSetup) unsetProxy() error {
 			{"networksetup", "-setsecurewebproxystate", serviceName, "off"},
 		}
 		for _, cmd := range commands {
-			if output, err := s.runCommand(cmd); err != nil {
+			if output, err := s.runCommand(cmd, true); err != nil {
 				errs.WriteString(fmt.Sprintf("cmd: %v\noutput: %s\nerr: %s\n", cmd, output, err))
 			} else {
 				isSuccess = true
@@ -113,17 +116,50 @@ func (s *SystemSetup) unsetProxy() error {
 		return nil
 	}
 
-	return fmt.Errorf("failed to unset proxy for any active network service, errs:%s", errs)
+	return fmt.Errorf("failed to unset proxy for any active network service, errs:%s", errs.String())
 }
 
 func (s *SystemSetup) installCert() (string, error) {
-	_, err := s.initCert()
-	if err != nil {
-		return "", err
-	}
-	output, err := s.runCommand([]string{"security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", "/Library/Keychains/System.keychain", s.CertFile})
+	output, err := s.runCommand([]string{"security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", "/Library/Keychains/System.keychain", s.CertFile}, true)
 	if err != nil {
 		return string(output), err
 	}
 	return "", nil
+}
+
+func (s *SystemSetup) isCertInstalled() (bool, error) {
+	fingerprint, err := s.certFingerprintSHA1()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	output, err := s.runCommand([]string{"security", "find-certificate", "-Z", "-a", "/Library/Keychains/System.keychain"}, false)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(strings.ToUpper(string(output)), fingerprint), nil
+}
+
+func (s *SystemSetup) removeCert() error {
+	installed, err := s.isCertInstalled()
+	if err != nil {
+		return err
+	}
+	if !installed {
+		return nil
+	}
+
+	fingerprint, err := s.certFingerprintSHA1()
+	if err != nil {
+		return err
+	}
+
+	output, err := s.runCommand([]string{"security", "delete-certificate", "-Z", fingerprint, "/Library/Keychains/System.keychain"}, true)
+	if err != nil {
+		return fmt.Errorf("remove trusted cert failed: %s\noutput: %s", err.Error(), string(output))
+	}
+	return nil
 }

--- a/core/system_linux.go
+++ b/core/system_linux.go
@@ -29,9 +29,11 @@ func (s *SystemSetup) runCommand(args []string, sudo bool) ([]byte, error) {
 	}
 
 	var cmd *exec.Cmd
-	if s.Password != "" && sudo {
+	if sudo && s.Password != "" {
 		cmd = exec.Command("sudo", append([]string{"-S"}, args...)...)
 		cmd.Stdin = bytes.NewReader([]byte(s.Password + "\n"))
+	} else if sudo {
+		cmd = exec.Command("sudo", args...)
 	} else {
 		cmd = exec.Command(args[0], args[1:]...)
 	}
@@ -76,35 +78,33 @@ func (s *SystemSetup) unsetProxy() error {
 	return nil
 }
 
-func (s *SystemSetup) installCert() (string, error) {
-	_, err := s.initCert()
-	if err != nil {
-		return "", err
+func (s *SystemSetup) linuxCertTarget(distro string) (string, []string) {
+	switch distro {
+	case "deepin":
+		return "/usr/share/ca-certificates/" + appOnce.AppName + "/" + appOnce.AppName + ".crt", []string{"update-ca-certificates"}
+	case "arch":
+		return "/usr/share/ca-certificates/trust-source/" + appOnce.AppName + ".crt", []string{"update-ca-trust"}
+	default:
+		return "/usr/local/share/ca-certificates/" + appOnce.AppName + ".crt", []string{"update-ca-certificates"}
 	}
+}
 
+func (s *SystemSetup) installCert() (string, error) {
 	distro, err := s.getLinuxDistro()
 	if err != nil {
 		return "", fmt.Errorf("detect distro failed: %w", err)
 	}
 
-	certName := appOnce.AppName + ".crt"
-	var certPath string
-	var updateCmd = []string{"update-ca-certificates"}
-
-	switch distro {
-	case "deepin":
-		certDir := "/usr/share/ca-certificates/" + appOnce.AppName
-		certPath = certDir + "/" + certName
-		s.runCommand([]string{"mkdir", "-p", certDir}, true)
-	case "arch":
-		certPath = "/usr/share/ca-certificates/trust-source/" + certName
-		updateCmd = []string{"update-ca-trust"}
-	default:
-		certPath = "/usr/local/share/ca-certificates/" + certName
-	}
-
+	certPath, updateCmd := s.linuxCertTarget(distro)
 	var outs, errs strings.Builder
 	isSuccess := false
+
+	if distro == "deepin" {
+		certDir := "/usr/share/ca-certificates/" + appOnce.AppName
+		if output, err := s.runCommand([]string{"mkdir", "-p", certDir}, true); err != nil {
+			errs.WriteString(fmt.Sprintf("mkdir cert dir failed: %s\n%s\n", err.Error(), output))
+		}
+	}
 
 	if output, err := s.runCommand([]string{"cp", "-f", s.CertFile, certPath}, true); err != nil {
 		errs.WriteString(fmt.Sprintf("copy cert failed: %s\n%s\n", err.Error(), output))
@@ -115,9 +115,10 @@ func (s *SystemSetup) installCert() (string, error) {
 
 	if distro == "deepin" {
 		confPath := "/etc/ca-certificates.conf"
-		checkCmd := []string{"grep", "-qxF", certName, confPath}
+		entry := appOnce.AppName + "/" + appOnce.AppName + ".crt"
+		checkCmd := []string{"grep", "-qxF", entry, confPath}
 		if _, err := s.runCommand(checkCmd, true); err != nil {
-			echoCmd := []string{"bash", "-c", fmt.Sprintf("echo '%s/%s' >> %s", appOnce.AppName, certName, confPath)}
+			echoCmd := []string{"bash", "-c", fmt.Sprintf("echo '%s' >> %s", entry, confPath)}
 			if output, err := s.runCommand(echoCmd, true); err != nil {
 				errs.WriteString(fmt.Sprintf("append conf failed: %s\n%s\n", err.Error(), output))
 			} else {
@@ -139,4 +140,73 @@ func (s *SystemSetup) installCert() (string, error) {
 	}
 
 	return outs.String(), fmt.Errorf("certificate installation failed:\n%s", errs.String())
+}
+
+func (s *SystemSetup) isCertInstalled() (bool, error) {
+	localCert, err := os.ReadFile(s.CertFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	distro, err := s.getLinuxDistro()
+	if err != nil {
+		return false, err
+	}
+
+	targetPath, _ := s.linuxCertTarget(distro)
+	systemCert, err := os.ReadFile(targetPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return bytes.Equal(localCert, systemCert), nil
+}
+
+func (s *SystemSetup) removeCert() error {
+	distro, err := s.getLinuxDistro()
+	if err != nil {
+		return err
+	}
+
+	targetPath, updateCmd := s.linuxCertTarget(distro)
+	var errs strings.Builder
+	changed := false
+
+	if _, err := os.Stat(targetPath); err == nil {
+		if output, err := s.runCommand([]string{"rm", "-f", targetPath}, true); err != nil {
+			errs.WriteString(fmt.Sprintf("remove cert file failed: %s\n%s\n", err.Error(), output))
+		} else {
+			changed = true
+		}
+	}
+
+	if distro == "deepin" {
+		confPath := "/etc/ca-certificates.conf"
+		entry := appOnce.AppName + "/" + appOnce.AppName + ".crt"
+		cmd := []string{"bash", "-c", fmt.Sprintf("grep -vxF '%s' %s > %s.tmp || true; mv %s.tmp %s", entry, confPath, confPath, confPath, confPath)}
+		if output, err := s.runCommand(cmd, true); err == nil {
+			changed = true
+			_ = output
+		}
+	}
+
+	if !changed && errs.Len() == 0 {
+		return nil
+	}
+
+	if output, err := s.runCommand(updateCmd, true); err != nil {
+		errs.WriteString(fmt.Sprintf("refresh trust store failed: %s\n%s\n", err.Error(), output))
+	}
+
+	if errs.Len() > 0 {
+		return fmt.Errorf("remove trusted cert failed:\n%s", errs.String())
+	}
+
+	return nil
 }

--- a/core/system_windows.go
+++ b/core/system_windows.go
@@ -3,12 +3,15 @@
 package core
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"os"
+	"unsafe"
+
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
-	"unsafe"
 )
 
 func (s *SystemSetup) setProxy() error {
@@ -43,41 +46,122 @@ func (s *SystemSetup) unsetProxy() error {
 	return nil
 }
 
-func (s *SystemSetup) installCert() (string, error) {
-	certData, err := s.initCert()
+func (s *SystemSetup) loadCertificateContext() (*x509.Certificate, error) {
+	certData, err := os.ReadFile(s.CertFile)
 	if err != nil {
-		return "", errors.New("installCert1:" + err.Error())
+		return nil, err
 	}
 
 	block, _ := pem.Decode(certData)
 	if block == nil {
-		return "", errors.New("Failed to parse certificate PEM" + err.Error())
+		return nil, errors.New("failed to parse certificate PEM")
 	}
 
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return "", errors.New("installCert3:" + err.Error())
-	}
+	return x509.ParseCertificate(block.Bytes)
+}
 
+func (s *SystemSetup) openRootStore() (windows.Handle, error) {
 	rootStorePtr, err := windows.UTF16PtrFromString("ROOT")
 	if err != nil {
-		return "", errors.New("installCert4:" + err.Error())
+		return 0, err
 	}
 
-	store, err := windows.CertOpenStore(windows.CERT_STORE_PROV_SYSTEM, 0, 0, windows.CERT_SYSTEM_STORE_LOCAL_MACHINE, uintptr(unsafe.Pointer(rootStorePtr)))
+	return windows.CertOpenStore(windows.CERT_STORE_PROV_SYSTEM, 0, 0, windows.CERT_SYSTEM_STORE_LOCAL_MACHINE, uintptr(unsafe.Pointer(rootStorePtr)))
+}
+
+func (s *SystemSetup) installCert() (string, error) {
+	cert, err := s.loadCertificateContext()
 	if err != nil {
-		return "", errors.New("installCert5:" + err.Error())
+		return "", errors.New("install cert: " + err.Error())
+	}
+
+	store, err := s.openRootStore()
+	if err != nil {
+		return "", errors.New("open root store: " + err.Error())
 	}
 	defer windows.CertCloseStore(store, 0)
 
 	certContext, err := windows.CertCreateCertificateContext(windows.X509_ASN_ENCODING|windows.PKCS_7_ASN_ENCODING, &cert.Raw[0], uint32(len(cert.Raw)))
 	if err != nil {
-		return "", errors.New("installCert6:" + err.Error())
+		return "", errors.New("create certificate context: " + err.Error())
 	}
 	defer windows.CertFreeCertificateContext(certContext)
+
 	err = windows.CertAddCertificateContextToStore(store, certContext, windows.CERT_STORE_ADD_REPLACE_EXISTING, nil)
 	if err != nil {
-		return "", errors.New("installCert7:" + err.Error())
+		return "", errors.New("add certificate to store: " + err.Error())
 	}
 	return "", nil
+}
+
+func (s *SystemSetup) isCertInstalled() (bool, error) {
+	targetCert, err := s.loadCertificateContext()
+	if err != nil {
+		return false, err
+	}
+
+	store, err := s.openRootStore()
+	if err != nil {
+		return false, err
+	}
+	defer windows.CertCloseStore(store, 0)
+
+	var current *windows.CertContext
+	for {
+		next, err := windows.CertEnumCertificatesInStore(store, current)
+		if next == nil {
+			if current != nil {
+				windows.CertFreeCertificateContext(current)
+			}
+			if err != nil {
+				return false, nil
+			}
+			return false, nil
+		}
+
+		encoded := unsafe.Slice(next.EncodedCert, next.Length)
+		if bytes.Equal(encoded, targetCert.Raw) {
+			windows.CertFreeCertificateContext(next)
+			return true, nil
+		}
+
+		current = next
+	}
+}
+
+func (s *SystemSetup) removeCert() error {
+	targetCert, err := s.loadCertificateContext()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	store, err := s.openRootStore()
+	if err != nil {
+		return err
+	}
+	defer windows.CertCloseStore(store, 0)
+
+	var current *windows.CertContext
+	for {
+		next, err := windows.CertEnumCertificatesInStore(store, current)
+		if next == nil {
+			if current != nil {
+				windows.CertFreeCertificateContext(current)
+			}
+			if err != nil {
+				return nil
+			}
+			return nil
+		}
+
+		encoded := unsafe.Slice(next.EncodedCert, next.Length)
+		if bytes.Equal(encoded, targetCert.Raw) {
+			return windows.CertDeleteCertificateFromStore(next)
+		}
+
+		current = next
+	}
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,7 +46,7 @@ C:\Users\Administrator\AppData\Roaming\res-downloader
 
 - Mac手动安装证书(V3+版本支持)，打开终端复制以下命令 粘贴到终端回车 按照提示输入密码，完成后再打开软件：
 ```shell
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /Users/$(whoami)/Library/Preferences/res-downloader/cert.crt && touch /Users/$(whoami)/Library/Preferences/res-downloader/install.lock && echo "安装完成"
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /Users/$(whoami)/Library/Preferences/res-downloader/ca.crt && echo "安装完成"
 ```
 
 ## 拦截不到小程序中的资源
@@ -71,8 +71,6 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 > [在线下载](https://m3u8-down.gowas.cn/)、[在线预览](https://m3u8play.com/)
 
 ## 安装证书后还会提示安装
-使用命令行打开本软件，查看 “lockfile:” 这串字符后面的锁文件路径，然后创建该文件即可  
-例如 mac系统下终端执行如下命令即可创建  
-> touch /Users/你的用户名/Library/Preferences/res-downloader/install.lock
+使用命令行打开本软件，查看 “certfile:” 后面的证书路径，确认本地证书文件存在且已成功导入系统受信任根证书即可
 
 ## 更多问题 请前往github进行[反馈](https://github.com/putyy/res-downloader/issues)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 	"log"
+	"os"
 	"res-downloader/core"
 	"runtime"
 
@@ -27,6 +28,14 @@ var icon []byte
 var wailsJson string
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--cleanup-system" {
+		if err := core.CleanupSystemState(wailsJson); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Create an instance of the app structure
 	app := core.GetApp(assets, wailsJson)
 	bind := core.NewBind()
@@ -63,7 +72,7 @@ func main() {
 
 			log.Println(logo)
 			fmt.Println("version:", app.Version)
-			fmt.Println("lockfile:", app.LockFile)
+			fmt.Println("certfile:", core.GetSystemCertFile())
 			app.Startup(ctx)
 		},
 		OnShutdown: func(ctx context.Context) {


### PR DESCRIPTION
## Summary
- replace the shared embedded root certificate/private key with a per-machine local CA generated on first run
- stop relying on install.lock and detect certificate installation against the real system trust store
- cleanup trusted certs during app exit, reset, and Windows uninstall via a non-UI cleanup entrypoint
- update troubleshooting docs to reflect the new cert path and behavior

## Verification
- npm install
- npm run build
- go test ./...
- go build ./...
- GOOS=windows GOARCH=amd64 go build ./...
- GOOS=linux GOARCH=amd64 go build ./...
- go run /tmp/res_downloader_cert_smoke.go
- go run . --cleanup-system

## Notes
- this keeps the existing install/proxy API surface intact while removing the shared CA material from source control
- normal app exit now attempts best-effort certificate cleanup, so users may need to re-install trust on the next launch if they want interception again