### PR TITLE
fix: accept 206 status code for single-part download

### DIFF
--- a/core/downloader.go
+++ b/core/downloader.go
@@ -359,7 +359,7 @@ func (fd *FileDownloader) doDownloadTask(progressChan chan ProgressChan, task *D
 
 	if fd.IsMultiPart && resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("server does not support range requests, status: %d", resp.StatusCode)
-	} else if !fd.IsMultiPart && resp.StatusCode != http.StatusOK {
+	} else if !fd.IsMultiPart && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
@@ -404,10 +404,21 @@ func (fd *FileDownloader) verifyDownload() error {
 		}
 	}
 
+	var written int64
+	for _, task := range fd.DownloadTaskList {
+		written += task.downloadedSize
+	}
+
 	if fd.TotalSize > 0 {
 		_, err := fd.File.Stat()
 		if err != nil {
 			return fmt.Errorf("get file info failed: %w", err)
+		}
+		// 服务器返回不足预期长度时, 去掉预分配的空白尾部, 避免留下打不开的空壳文件
+		if written > 0 && written < fd.TotalSize {
+			if err := fd.File.Truncate(written); err != nil {
+				return fmt.Errorf("truncate file failed: %w", err)
+			}
 		}
 	}
 

--- a/core/downloader_test.go
+++ b/core/downloader_test.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// 复现 bug: 服务器对无 Range 的请求也回 206(部分内容), 单段下载应接受而非报错
+func TestDownloadAccepts206WithoutRange(t *testing.T) {
+	globalConfig = &Config{}
+	globalLogger = NewLogger(false, "")
+	body := make([]byte, 1024*100) // 100KB
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", fmt.Sprint(len(body))) // 不声明 Accept-Ranges → 单段模式
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(body)-1, len(body)))
+		w.WriteHeader(http.StatusPartialContent) // 206
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "out.mp4")
+	fd := NewFileDownloader(srv.URL, out, 1, map[string]string{})
+	if err := fd.Start(); err != nil {
+		t.Fatalf("206 下载失败(回归): %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(body) {
+		t.Fatalf("文件长度 %d != 预期 %d", len(got), len(body))
+	}
+	for i := range got {
+		if got[i] != body[i] {
+			t.Fatalf("第 %d 字节不一致", i)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

`download failed with 1 errors: task 0 failed after 3attempts: unexpected status code: 206`（issue #316）。

部分视频 CDN（尤其流媒体服务器）即使收到不带 `Range` 头的下载请求，也总是返回 `206 Partial Content` 而非 `200 OK`。单段下载器只接受 `200`，遇到 `206` 会判定为失败并重试，最终留下一个预分配的全空白占位文件 —— 用户打开该文件表现为"无声音 / 不兼容 / 打不开"。

## 修复

- `core/downloader.go`：单段模式下同时接受 `200` 与 `206`（`206` 在不带 `Range` 时其 body 即完整内容）。
- 同一提交补充保险：`verifyDownload` 按实际写入字节数截断文件，避免服务器返回内容短于预期时尾部残留空白。
- 新增回归测试 `core/downloader_test.go`：用 `httptest` 模拟"无 Range 请求也回 206"的服务器，验证下载成功且字节一致。

## 验证

```sh
go test -vet=off ./core/ -run TestDownloadAccepts206WithoutRange -v
# PASS
```