### PR TITLE
fix: 修复捕获 Range 请求导致仅下载视频分片

### DIFF
--- a/core/downloader.go
+++ b/core/downloader.go
@@ -85,6 +85,8 @@ func (fd *FileDownloader) buildClient() *http.Client {
 var forbiddenDownloadHeaders = map[string]struct{}{
 	"accept-encoding":   {},
 	"content-length":    {},
+	"range":             {},
+	"if-range":          {},
 	"host":              {},
 	"connection":        {},
 	"keep-alive":        {},
@@ -108,15 +110,16 @@ var forbiddenDownloadHeaders = map[string]struct{}{
 
 func (fd *FileDownloader) setHeaders(request *http.Request) {
 	for key, value := range fd.Headers {
+		lk := strings.ToLower(key)
+		if _, forbidden := forbiddenDownloadHeaders[lk]; forbidden {
+			continue
+		}
+
 		if globalConfig.UseHeaders == "default" {
-			lk := strings.ToLower(key)
-			if _, forbidden := forbiddenDownloadHeaders[lk]; forbidden {
-				continue
-			}
 			request.Header.Set(key, value)
 			continue
 		}
-		
+
 		if strings.Contains(globalConfig.UseHeaders, key) {
 			request.Header.Set(key, value)
 		}

--- a/core/downloader_test.go
+++ b/core/downloader_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetHeadersDropsCapturedRange(t *testing.T) {
+	oldConfig := globalConfig
+	globalConfig = &Config{UseHeaders: "default"}
+	t.Cleanup(func() { globalConfig = oldConfig })
+
+	downloader := NewFileDownloader("https://example.com/video.mp4", "video.mp4", 1, map[string]string{
+		"Range":      "bytes=0-65535",
+		"If-Range":   "etag-value",
+		"User-Agent": "test-agent",
+		"Referer":    "https://example.com/",
+	})
+	request, err := http.NewRequest(http.MethodGet, downloader.Url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	downloader.setHeaders(request)
+
+	if got := request.Header.Get("Range"); got != "" {
+		t.Fatalf("captured Range header leaked into full download: %q", got)
+	}
+	if got := request.Header.Get("If-Range"); got != "" {
+		t.Fatalf("captured If-Range header leaked into full download: %q", got)
+	}
+	if got := request.Header.Get("User-Agent"); got != "test-agent" {
+		t.Fatalf("User-Agent was not preserved: %q", got)
+	}
+	if got := request.Header.Get("Referer"); got != "https://example.com/" {
+		t.Fatalf("Referer was not preserved: %q", got)
+	}
+}
+
+func TestSetHeadersDropsCapturedRangeWithCustomHeaderList(t *testing.T) {
+	oldConfig := globalConfig
+	globalConfig = &Config{UseHeaders: "User-Agent,Referer,Range,If-Range"}
+	t.Cleanup(func() { globalConfig = oldConfig })
+
+	downloader := NewFileDownloader("https://example.com/video.mp4", "video.mp4", 1, map[string]string{
+		"Range":      "bytes=0-65535",
+		"If-Range":   "etag-value",
+		"User-Agent": "test-agent",
+	})
+	request, err := http.NewRequest(http.MethodGet, downloader.Url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	downloader.setHeaders(request)
+
+	if got := request.Header.Get("Range"); got != "" {
+		t.Fatalf("captured Range header leaked with custom headers: %q", got)
+	}
+	if got := request.Header.Get("If-Range"); got != "" {
+		t.Fatalf("captured If-Range header leaked with custom headers: %q", got)
+	}
+	if got := request.Header.Get("User-Agent"); got != "test-agent" {
+		t.Fatalf("User-Agent was not preserved: %q", got)
+	}
+}

--- a/core/plugins/plugin.default.go
+++ b/core/plugins/plugin.default.go
@@ -27,6 +27,26 @@ func (p *DefaultPlugin) OnRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*http
 	return r, nil
 }
 
+// responseSize returns the size of the complete resource. For a 206 response,
+// Content-Length is only the size of the requested range, while Content-Range
+// carries the full object size (for example: "bytes 0-65535/1234567").
+func responseSize(resp *http.Response) float64 {
+	if resp.StatusCode == http.StatusPartialContent {
+		contentRange := resp.Header.Get("Content-Range")
+		if slash := strings.LastIndex(contentRange, "/"); slash >= 0 {
+			total := strings.TrimSpace(contentRange[slash+1:])
+			if total != "" && total != "*" {
+				if value, err := strconv.ParseFloat(total, 64); err == nil {
+					return value
+				}
+			}
+		}
+	}
+
+	value, _ := strconv.ParseFloat(resp.Header.Get("Content-Length"), 64)
+	return value
+}
+
 func (p *DefaultPlugin) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 	if resp == nil || resp.Request == nil || (resp.StatusCode != 200 && resp.StatusCode != 206 && resp.StatusCode != 304) {
 		return resp
@@ -50,7 +70,7 @@ func (p *DefaultPlugin) OnResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *
 
 	urlSign := shared.Md5(rawUrl)
 	if ok := p.bridge.MediaIsMarked(urlSign); !ok && (isAll || isClassify) {
-		value, _ := strconv.ParseFloat(resp.Header.Get("content-length"), 64)
+		value := responseSize(resp)
 		id, err := gonanoid.New()
 		if err != nil {
 			id = urlSign

--- a/core/plugins/plugin_default_test.go
+++ b/core/plugins/plugin_default_test.go
@@ -1,0 +1,33 @@
+package plugins
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestResponseSizeUsesContentRangeTotal(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusPartialContent,
+		Header: http.Header{
+			"Content-Length": {"65536"},
+			"Content-Range":  {"bytes 0-65535/1234567"},
+		},
+	}
+
+	if got := responseSize(resp); got != 1234567 {
+		t.Fatalf("responseSize() = %v, want 1234567", got)
+	}
+}
+
+func TestResponseSizeFallsBackToContentLength(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Length": {"7654321"},
+		},
+	}
+
+	if got := responseSize(resp); got != 7654321 {
+		t.Fatalf("responseSize() = %v, want 7654321", got)
+	}
+}


### PR DESCRIPTION
## 问题

当媒体播放请求返回 `206 Partial Content` 时，程序会保存原始请求中的 `Range` / `If-Range` 请求头。后续下载任务复用这些请求头，导致只下载被捕获的字节范围，而不是完整视频。列表中显示的资源大小也会错误地使用分片的 `Content-Length`。

该问题可在 macOS 抖音桌面端的分段视频请求中稳定触发。

## 修复

- 下载时始终过滤捕获到的 `Range` 和 `If-Range` 请求头，包括自定义请求头模式
- 对 `206` 响应解析 `Content-Range` 的总大小，缺失时回退到 `Content-Length`
- 增加默认请求头、自定义请求头及资源大小解析的回归测试

## 验证

- `go test -vet=off ./core/...`
- `wails build -platform darwin/arm64 -clean`
